### PR TITLE
Add support for Rails generators

### DIFF
--- a/lib/generators/pavlov/command_generator.rb
+++ b/lib/generators/pavlov/command_generator.rb
@@ -1,0 +1,11 @@
+require 'rails/generators'
+
+module Pavlov
+  class CommandGenerator < Rails::Generators::NamedBase
+    source_root File.expand_path('../templates', __FILE__)
+
+    def create_command_file
+      template 'command.rb', File.join('app/use_cases/commands', "#{singular_table_name}.rb")
+    end
+  end
+end

--- a/lib/generators/pavlov/interactor_generator.rb
+++ b/lib/generators/pavlov/interactor_generator.rb
@@ -1,0 +1,11 @@
+require 'rails/generators'
+
+module Pavlov
+  class InteractorGenerator < Rails::Generators::NamedBase
+    source_root File.expand_path('../templates', __FILE__)
+
+    def create_interactor_file
+      template 'interactor.rb', File.join('app/use_cases/interactors', "#{singular_table_name}.rb")
+    end
+  end
+end

--- a/lib/generators/pavlov/query_generator.rb
+++ b/lib/generators/pavlov/query_generator.rb
@@ -1,0 +1,17 @@
+require 'rails/generators'
+
+module Pavlov
+  class QueryGenerator < Rails::Generators::NamedBase
+    source_root File.expand_path('../templates', __FILE__)
+
+    def create_query_file
+      template 'query.rb', File.join('app/use_cases/queries', "#{singular_table_name}.rb")
+    end
+
+    # This would invoke whatever test framework is defined,
+    # but none seem to have any way of generating for just
+    # any old object instead of "model" or "helper" etc...
+    #
+    # hook_for :test_framework
+  end
+end

--- a/lib/generators/pavlov/templates/command.rb
+++ b/lib/generators/pavlov/templates/command.rb
@@ -1,0 +1,8 @@
+module Commands
+  class <%= class_name %>
+    include Pavlov::Command
+
+    def execute
+    end
+  end
+end

--- a/lib/generators/pavlov/templates/interactor.rb
+++ b/lib/generators/pavlov/templates/interactor.rb
@@ -1,0 +1,14 @@
+module Interactors
+  class <%= class_name %>
+    include Pavlov::Interactor
+
+    def execute
+    end
+
+    private
+
+    def authorized?
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/generators/pavlov/templates/query.rb
+++ b/lib/generators/pavlov/templates/query.rb
@@ -1,0 +1,8 @@
+module Queries
+  class <%= class_name %>
+    include Pavlov::Query
+
+    def execute
+    end
+  end
+end

--- a/lib/pavlov.rb
+++ b/lib/pavlov.rb
@@ -28,6 +28,7 @@ module Pavlov
   end
 end
 
+require_relative 'pavlov/engine' if defined?(Rails)
 require_relative 'pavlov/helpers'
 require_relative 'pavlov/access_denied'
 require_relative 'pavlov/validation_error'

--- a/lib/pavlov/engine.rb
+++ b/lib/pavlov/engine.rb
@@ -1,0 +1,6 @@
+require 'rails'
+
+module Pavlov
+  class Engine < Rails::Engine
+  end
+end


### PR DESCRIPTION
If anyone knows how to add tests for this, I'd love to add them. This stuff seems a bit under-documented in Rails, so  there were no examples of how to add tests.

I could write something that actually executes `rails generate pavlov:query` etc, but that seems incredibly slow...

In addition, I'd also love it if these generated the corresponding spec files, but rspec-rails doesn't provide generators for generic classes, only models, views etc. Might be an idea to add support for that to rspec-rails, so we can use it here. Ofcourse, then we'd also have to investigate how that works with Test::Unit and Minitest.
