### PR TITLE
validate should raise when input is invalid

### DIFF
--- a/lib/pavlov/operation.rb
+++ b/lib/pavlov/operation.rb
@@ -20,9 +20,9 @@ module Pavlov
 
     def validate
       if respond_to? :valid?
-        valid?
+        raise Pavlov::ValidationError, "an argument is invalid" unless valid?
       else
-        true
+        true # noop
       end
     end
 


### PR DESCRIPTION
maybe we want to change this behaviour later, but
for now the interface should be consistent between
when we use valid? and validate.
