### PR TITLE
Validation should fail if attribute is defined without a default value and no value was set.

### DIFF
--- a/lib/pavlov/operation.rb
+++ b/lib/pavlov/operation.rb
@@ -12,6 +12,7 @@ module Pavlov
     include Virtus
 
     def validate
+      return false unless attributes_without_defaults_have_values
       if respond_to? :valid?
         valid?
       else
@@ -37,6 +38,13 @@ module Pavlov
 
     def check_authorization
       raise_unauthorized if respond_to? :authorized?, true and not authorized?
+    end
+
+    def attributes_without_defaults_have_values
+      attributes_without_value = attribute_set.select do |attribute|
+        not attribute.options.has_key?(:default) and send(attribute.name).nil?
+      end
+      attributes_without_value.empty?
     end
 
     module ClassMethods

--- a/spec/pavlov/operation_spec.rb
+++ b/spec/pavlov/operation_spec.rb
@@ -31,6 +31,36 @@ describe Pavlov::Operation do
     end
   end
 
+  describe 'validations' do
+    describe 'check if attributes without defaults have were given a value' do
+      it 'passes when given a value' do
+        dummy_class = Class.new do
+          include Pavlov::Operation
+          attribute :title, String
+        end
+        expect(dummy_class.new(title: 'Title').validate).to be_true
+      end
+
+      it 'passes when given a default' do
+        dummy_class = Class.new do
+          include Pavlov::Operation
+          attribute :title,   String, default: "A title"
+          attribute :date,    Time,   default: lambda { Time.now }
+          attribute :visible, String, default: nil
+        end
+        expect(dummy_class.new.validate).to be_true
+      end
+
+      it 'fails when not given a value' do
+        dummy_class = Class.new do
+          include Pavlov::Operation
+          attribute :title, String
+        end
+        expect(dummy_class.new.validate).to be_false
+      end
+    end
+  end
+
   describe '.check_authority' do
     before do
       stub_const 'Pavlov::AccessDenied', StandardError


### PR DESCRIPTION
We might want to have a look at validations altogether (now or at some later point). I think `#call` should raise an exception if operation is not valid, but `#valid?` should not.
