### PR TITLE
Made Pavlov.old_{stuff} use Pavlov.{stuff}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+Made `Pavlov.old_command`, `old_query` and `old_interactor` use `Pavlov.command`, `Pavlov.query` and `Pavlov.interactor` so you can upgrade expectations in a forward compatible manner.
+
 ## 0.1.4
 
 Added license to gemspec

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,7 @@
+## HEAD
+
+* Change your expectations to expect `Pavlov.command` with hash arguments instead of `Pavlov.old_command` with positional arguments. Same for `query` and `interactor`
+
 ## 0.1.4
 
 * If you use validations, you must now either use alpha_compatibility, or copy them to your own codebase.

--- a/lib/pavlov.rb
+++ b/lib/pavlov.rb
@@ -10,21 +10,35 @@ module Pavlov
   end
 
   def self.command command_name, *args
+    klass = class_for_command(command_name)
+    klass.new(*args).call
+  end
+
+  def self.interactor interactor_name, *args
+    klass = class_for_interactor(interactor_name)
+    klass.new(*args).call
+  end
+
+  def self.query query_name, *args
+    klass = class_for_query(query_name)
+    klass.new(*args).call
+  end
+
+  private
+
+  def self.class_for_command command_name
     class_name = 'Commands::' + string_to_classname(command_name)
-    klass = get_class_by_string(class_name)
-    klass.new(*args).call
+    get_class_by_string(class_name)
   end
 
-  def self.interactor command_name, *args
-    class_name = 'Interactors::' + string_to_classname(command_name)
-    klass = get_class_by_string class_name
-    klass.new(*args).call
+  def self.class_for_interactor interactor_name
+    class_name = 'Interactors::' + string_to_classname(interactor_name)
+    get_class_by_string(class_name)
   end
 
-  def self.query command_name, *args
-    class_name = 'Queries::' + string_to_classname(command_name)
-    klass = get_class_by_string class_name
-    klass.new(*args).call
+  def self.class_for_query query_name
+    class_name = 'Queries::' + string_to_classname(query_name)
+    get_class_by_string(class_name)
   end
 end
 

--- a/lib/pavlov/alpha_compatibility.rb
+++ b/lib/pavlov/alpha_compatibility.rb
@@ -2,24 +2,18 @@ require 'pavlov'
 
 module Pavlov
   def self.old_command command_name, *args
-    class_name = 'Commands::' + string_to_classname(command_name)
-    klass = get_class_by_string(class_name)
-    attributes = arguments_to_attributes(klass, args)
-    klass.new(attributes).call
+    klass = class_for_command(command_name)
+    command command_name, arguments_to_attributes(klass, args)
   end
 
-  def self.old_interactor command_name, *args
-    class_name = 'Interactors::' + string_to_classname(command_name)
-    klass = get_class_by_string class_name
-    attributes = arguments_to_attributes(klass, args)
-    klass.new(attributes).call
+  def self.old_interactor interactor_name, *args
+    klass = class_for_interactor(interactor_name)
+    interactor interactor_name, arguments_to_attributes(klass, args)
   end
 
-  def self.old_query command_name, *args
-    class_name = 'Queries::' + string_to_classname(command_name)
-    klass = get_class_by_string class_name
-    attributes = arguments_to_attributes(klass, args)
-    klass.new(attributes).call
+  def self.old_query query_name, *args
+    klass = class_for_query(query_name)
+    query query_name, arguments_to_attributes(klass, args)
   end
 
   def self.arguments_to_attributes(operation_class, arguments)

--- a/spec/integration/alpha_compatibility_spec.rb
+++ b/spec/integration/alpha_compatibility_spec.rb
@@ -65,4 +65,24 @@ describe 'Pavlov Alpha Compatibility' do
       expect(old_interactor :shouty_greeting).to eq('OHAI, JOHN')
     end
   end
+
+  describe 'old_command style helper' do
+    before do
+      stub_const 'Commands::Test', Class.new
+      class Commands::Test
+        include Pavlov::Command
+
+        arguments :test_string
+        def execute
+        end
+      end
+    end
+
+    it 'redirects to regular Pavlov.command etc' do
+      Pavlov.should_receive(:command)
+            .with(:test, test_string: 'test')
+
+      old_command :test, 'test'
+    end
+  end
 end


### PR DESCRIPTION
Paving the upgrade path. We can now set expectations on the new shortcuts instead of the old shortcuts, so we can at some point eliminate the old shortcuts
