### PR TITLE
Update LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2013 Factlink, Inc
+Copyright (c) 2013 Factlink, Inc and individual contributors
 
 MIT License
 


### PR DESCRIPTION
Since Pavlov does not have a Contributor License Agreement that transfers the ownership of copyright, the first line of the LICENSE was incorrect.
