### PR TITLE
use error object in validation helpers

### DIFF
--- a/lib/pavlov/alpha_compatibility.rb
+++ b/lib/pavlov/alpha_compatibility.rb
@@ -8,7 +8,7 @@ module Pavlov
     def validate_hexadecimal_string param_name, param
       return if param.is_a?(String) && /\A[\da-fA-F]+\Z/.match(param)
 
-      errors.add param_name, "should be an hexadecimal string."
+      errors.add param_name, 'should be an hexadecimal string.'
     end
 
     def validate_regex param_name, param, regex, message
@@ -21,37 +21,37 @@ module Pavlov
       return if opts[:allow_blank] && param.blank?
       return if param.is_a?(Integer)
 
-      errors.add param_name, "should be an integer."
+      errors.add param_name, 'should be an integer.'
     end
 
     def validate_in_set param_name, param, set
       return if set.include? param
 
-      errors.add param_name, "should be on of these values: #{set.inspect}."
+      errors.add param_name, 'should be on of these values: #{set.inspect}.'
     end
 
     def validate_string param_name, param
       return if param.is_a?(String)
 
-      errors.add param_name, "should be a string."
+      errors.add param_name, 'should be a string.'
     end
 
     def validate_nonempty_string param_name, param
       return if param.is_a?(String) && !param.empty?
 
-      errors.add param_name, "should be a nonempty string."
+      errors.add param_name, 'should be a nonempty string.'
     end
 
     def validate_integer_string param_name, param
       return if param.is_a?(String) && /\A\d+\Z/.match(param)
 
-      errors.add param_name, "should be an integer string."
+      errors.add param_name, 'should be an integer string.'
     end
 
     def validate_not_nil param_name, param
       return unless param.nil?
 
-      errors.add param_name, "should not be nil."
+      errors.add param_name, 'should not be nil.'
     end
   end
 


### PR DESCRIPTION
I think we want to remove this eventually, but it seemed nicer to first have this code in the repo in a form that users can inline.
